### PR TITLE
bulit/integration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,9 @@
 ---
 # defaults file for weaselkeeper.logging
 use_rsyslog: true
-use_remote_rsyslog: true
+rsyslog_use_remote: true
 
 InjestIP: 127.0.0.1
 InjestPortSyslog: 514
 InjestProto: "udp"
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 use_rsyslog: true
 rsyslog_use_remote: true
 rsyslog_use_fqdn: true
+rsyslog_forwarder_filename: "60-logging-elks.conf"
 
 InjestIP: 127.0.0.1
 InjestPortSyslog: 514

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 # defaults file for weaselkeeper.logging
 use_rsyslog: true
 rsyslog_use_remote: true
+rsyslog_use_fqdn: true
 
 InjestIP: 127.0.0.1
 InjestPortSyslog: 514

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for weaselkeeper.logging
 use_rsyslog: true
-rsyslog_use_remote: true
+rsyslog_use_remote: false
 rsyslog_use_fqdn: true
 rsyslog_forwarder_filename: "60-logging-elks.conf"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,5 @@
 ---
 - import_tasks: syslog-elks.yml
   when:
-    - "'rsyslog_elks' in group_names"
+    - (("'rsyslog_elks' in group_names") or rsyslog_use_remote)
     - use_rsyslog
-    - rsyslog_use_remote

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,4 +3,4 @@
   when:
     - "'rsyslog_elks' in group_names"
     - use_rsyslog
-    - use_remote_rsyslog
+    - rsyslog_use_remote

--- a/tasks/syslog-elks.yml
+++ b/tasks/syslog-elks.yml
@@ -38,6 +38,6 @@
     validate: rsyslogd -N2 -f %s -f /etc/rsyslog.conf
   notify: restart rsyslog
   when:
-      - use_remote_rsyslog
+      - rsyslog_use_remote
 
 ...

--- a/tasks/syslog-elks.yml
+++ b/tasks/syslog-elks.yml
@@ -20,19 +20,18 @@
 
 - name: Set fact from rsyslog version
   set_fact:
-    rsyslog_ver_major: "{{ (rsyslog_status.stdout|from_json).version.split('.')[0]|int }}"
-    rsyslog_ver_minor: "{{ (rsyslog_status.stdout|from_json).version.split('.')[1]|int }}"
+    rsyslog_ver_major: "{{ (rsyslog_status.stdout|from_json).version.split('.')[0] }}"
+    rsyslog_ver_minor: "{{ (rsyslog_status.stdout|from_json).version.split('.')[1] }}"
   when:
     - rsyslog_status.stdout is defined
     - (rsyslog_status.stdout|from_json).status|trim == "ii"
-
 
 - name: Central log server does not need 'last message repeated'
   become: true
   lineinfile:
     path: /etc/rsyslog.conf
     line: '$RepeatedMsgReduction off'
-    regexp: '^\\$RepeatedMsgReduction  '
+    regexp: '^\$RepeatedMsgReduction '
     insertafter: "^# Filter duplicated messages"
     validate: rsyslogd -N2 -f %s
   notify: restart rsyslog
@@ -44,8 +43,8 @@
   lineinfile:
     path: /etc/rsyslog.conf
     line: '$PreserveFQDN on'
-    regexp: '^\\$PreserveFQDN '
-    insertbefore: "^\\$IncludeConfig "
+    regexp: '^\$PreserveFQDN '
+    insertbefore: '^\$IncludeConfig '
     validate: rsyslogd -N2 -f %s
   notify: restart rsyslog
   when:
@@ -56,7 +55,7 @@
   become_user: root
   template:
     src: rsyslog-elks.conf.j2
-    dest: /etc/rsyslog.d/60-logging-elks.conf
+    dest: "/etc/rsyslog.d/{{ rsyslog_forwarder_filename }}"
     mode: 0644
     owner: 0
     group: 0

--- a/tasks/syslog-elks.yml
+++ b/tasks/syslog-elks.yml
@@ -10,6 +10,13 @@
     - apt
     - packages
 
+- name: Set fact to unify variables
+  set_fact:
+    rsyslog_use_remote: true
+  when:
+    - "'rsyslog_elks' in group_names"
+    - not rsyslog_use_remote
+
 - name: Get rsyslog package status and version
   command: >
     dpkg-query --show \

--- a/tasks/syslog-elks.yml
+++ b/tasks/syslog-elks.yml
@@ -26,6 +26,19 @@
     - rsyslog_status.stdout is defined
     - (rsyslog_status.stdout|from_json).status|trim == "ii"
 
+
+- name: Central log server does not need 'last message repeated'
+  become: true
+  lineinfile:
+    path: /etc/rsyslog.conf
+    line: '$RepeatedMsgReduction off'
+    regexp: '^\\$RepeatedMsgReduction  '
+    insertafter: "^# Filter duplicated messages"
+    validate: rsyslogd -N2 -f %s
+  notify: restart rsyslog
+  when:
+      - rsyslog_use_remote
+
 - name: When logging to central log server use full name
   become: true
   lineinfile:

--- a/tasks/syslog-elks.yml
+++ b/tasks/syslog-elks.yml
@@ -26,6 +26,18 @@
     - rsyslog_status.stdout is defined
     - (rsyslog_status.stdout|from_json).status|trim == "ii"
 
+- name: When logging to central log server use full name
+  become: true
+  lineinfile:
+    path: /etc/rsyslog.conf
+    line: '$PreserveFQDN on'
+    regexp: '^\\$PreserveFQDN '
+    insertbefore: "^\\$IncludeConfig "
+    validate: rsyslogd -N2 -f %s
+  notify: restart rsyslog
+  when:
+      - rsyslog_use_remote
+
 - name: Syslog to log to central log server
   become: true
   become_user: root

--- a/templates/rsyslog-elks.conf.j2
+++ b/templates/rsyslog-elks.conf.j2
@@ -4,7 +4,7 @@
   Target="{{ InjestIP }}"
   Port="{{ InjestPortSyslog }}"
   Protocol="{{ InjestProto }}"
-{% if InjestProto == "tcp" and rsyslog_ver_major|int >= 8 %}
+{% if InjestProto == "tcp" and rsyslog_ver_major|default(8)|int >= 8 %}
   KeepAlive="on"
   ResendLastMSGOnReconnect="on"
 {% endif %}

--- a/templates/rsyslog-elks.conf.j2
+++ b/templates/rsyslog-elks.conf.j2
@@ -1,4 +1,4 @@
-# /etc/rsyslog.d/60-logging-elks
+# /etc/rsyslog.d/{{ rsyslog_forwarder_filename }}
 *.*;syslog action(
   type="omfwd"
   Target="{{ InjestIP }}"


### PR DESCRIPTION
When logging to central log server
- use FQDN
- do not use "last message repeated n times"
- allow to define different filename
- role can be used or by adding `rsyslog_elks` group or by define `rsyslog_use_remote` variable