### PR TITLE
Hotfix: add `when` to pass ansible-lint

### DIFF
--- a/tasks/syslog-elks.yml
+++ b/tasks/syslog-elks.yml
@@ -22,6 +22,8 @@
     dpkg-query --show \
       --showformat '{"version":"${Version}","status":"${db:Status-Abbrev}"}' \
       rsyslog
+  when:
+    - rsyslog_use_remote
   register:
     rsyslog_status
 
@@ -43,7 +45,7 @@
     validate: rsyslogd -N2 -f %s
   notify: restart rsyslog
   when:
-      - rsyslog_use_remote
+    - rsyslog_use_remote
 
 - name: When logging to central log server use full name
   become: true
@@ -55,7 +57,7 @@
     validate: rsyslogd -N2 -f %s
   notify: restart rsyslog
   when:
-      - rsyslog_use_remote
+    - rsyslog_use_remote
 
 - name: Syslog to log to central log server
   become: true
@@ -69,6 +71,6 @@
     validate: rsyslogd -N2 -f %s -f /etc/rsyslog.conf
   notify: restart rsyslog
   when:
-      - rsyslog_use_remote
+    - rsyslog_use_remote
 
 ...


### PR DESCRIPTION
ANSIBLE0012: Commands should not change things if nothing needs doing

Commands should either read information (and thus set changed_when)
or not do something if it has already been done (using creates/removes)
or only do it if another check has a particular result (when)