### PR TITLE
add all (*) priorities to syslog internal facility

### DIFF
--- a/templates/rsyslog-elks.conf.j2
+++ b/templates/rsyslog-elks.conf.j2
@@ -1,5 +1,5 @@
 # /etc/rsyslog.d/{{ rsyslog_forwarder_filename }}
-*.*;syslog action(
+*.*;syslog.* action(
   type="omfwd"
   Target="{{ InjestIP }}"
   Port="{{ InjestPortSyslog }}"


### PR DESCRIPTION
when validating configuration rsyslog warns:
`rsyslogd: unknown priority name ""`