### PR TITLE
Small fixes

### DIFF
--- a/tasks/syslog-elks.yml
+++ b/tasks/syslog-elks.yml
@@ -24,6 +24,7 @@
       rsyslog
   when:
     - rsyslog_use_remote
+  changed_when: false
   register:
     rsyslog_status
 

--- a/tasks/syslog-elks.yml
+++ b/tasks/syslog-elks.yml
@@ -69,7 +69,7 @@
     mode: 0644
     owner: 0
     group: 0
-    validate: rsyslogd -N2 -f %s -f /etc/rsyslog.conf
+    validate: rsyslogd -N2 -f %s
   notify: restart rsyslog
   when:
     - rsyslog_use_remote


### PR DESCRIPTION
1. Command module always report “changed” status based on whether it thinks it affected machine state. We do not make any changes, so it shouldn't appears in reports or not cause handlers to fire.
1. validate only changed file (in temporary location) - there is an error when on host is broken file and we want to replace it. 